### PR TITLE
added the annualized rate for US overall

### DIFF
--- a/Data/Men/Homicide_Non-Firearms_White_NH_Males_Age-adjusted_2008-2014.txt
+++ b/Data/Men/Homicide_Non-Firearms_White_NH_Males_Age-adjusted_2008-2014.txt
@@ -3,7 +3,7 @@
 "2008-2014, United States","","","","","","",""
 "Age-adjusted Death Rates per 100,000 Population","","","","","","",""
 "Non-Firearm, Homicide, White, Non-Hispanic, Males, All Ages","","","","","","",""
-"Annualized Age-adjusted Rate for United States:  suppressed","","","","","","",""
+"Annualized Age-adjusted Rate for United States:  1.42","","","","","","",""
 "","","","","","","",""
 "","","","","","","",""
 "Reports for All Ages include those of unknown age.","","","","","","",""


### PR DESCRIPTION
For some reason, WISQARS suppressed the annual overall rate  when the data was converted to csv. However, it is provided in the original fatal injury map so I added this number back into the file.